### PR TITLE
Add About and Help pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import About from "./pages/About";
+import Help from "./pages/Help";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +18,8 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/help" element={<Help />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const About = () => (
+  <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="text-center p-6">
+      <h1 className="text-3xl font-bold mb-4">Sobre</h1>
+      <p className="text-lg text-gray-700 mb-2">
+        Este software foi criado por Giseldo Neo.
+      </p>
+      <p className="text-lg text-gray-700">
+        Contato: <a href="mailto:giseldo@gmail.com" className="text-blue-500 underline">giseldo@gmail.com</a>
+      </p>
+    </div>
+  </div>
+);
+
+export default About;

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const Help = () => (
+  <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="max-w-2xl p-6 text-gray-700">
+      <h1 className="text-3xl font-bold mb-4 text-center">Ajuda</h1>
+      <p className="mb-4">
+        Utilize o editor para escrever seu Markdown. No topo da tela, escolha o
+        modo <strong>Editar</strong> para digitar, <strong>Dividir</strong> para
+        visualizar editor e preview lado a lado e <strong>Preview</strong> para
+        ver apenas o resultado final.
+      </p>
+      <p>
+        O conteúdo é renderizado automaticamente conforme você digita, permitindo
+        acompanhar as alterações em tempo real.
+      </p>
+    </div>
+  </div>
+);
+
+export default Help;


### PR DESCRIPTION
## Summary
- create pages `About.tsx` and `Help.tsx`
- register these routes in `App.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854c92686f883329c08d5e600b960b4